### PR TITLE
Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,4 @@ Quality assurance is built into every phase through code reviews, automated test
 - [Project Lifecycle](project-lifecycle.md)
 - [Roles and Responsibilities](roles-responsibilities.md)
 - [Communication Plan](communication-plan.md)
+  


### PR DESCRIPTION
This pull request adds a README in the docs folder summarizing OctoAcme project management processes and linking all relevant documentation files.
Closes issue #<your-issue-number>
